### PR TITLE
Fix emoji for save settings button

### DIFF
--- a/pages/1_📥_Upload_&_Settings.py
+++ b/pages/1_📥_Upload_&_Settings.py
@@ -73,7 +73,7 @@ with st.expander("Save / Load Settings", expanded=False):
             path = save_prefs(prefs=prefs, include_keys=False)
             st.success(f"Saved to {path}")
     with c2:
-        if st.button("�� Save Settings (include keys)"):
+        if st.button("🔐 Save Settings (include keys)"):
             prefs["GEMINI_API_KEY"] = os.environ.get("GEMINI_API_KEY","")
             prefs["OPENAI_API_KEY"] = os.environ.get("OPENAI_API_KEY","")
             path = save_prefs(prefs=prefs, include_keys=True)


### PR DESCRIPTION
## Summary
- use lock emoji on save settings button when saving keys

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68acf51ba1308331b63f8c639403c4e7