### PR TITLE
Refactor taxonomy loading on Drivers & Visualization page

### DIFF
--- a/pages/2_📊_Drivers_&_Visualization.py
+++ b/pages/2_📊_Drivers_&_Visualization.py
@@ -2,7 +2,7 @@ import streamlit as st, pandas as pd, plotly.express as px, pathlib
 from analytics.tcd import load_rules, derive_drivers
 from analytics.cluster import iterative_other_reduction
 from analytics.llm_bridge import best_label_for_cluster
-from analytics.taxonomy import load_taxonomy_entries, map_text_to_taxonomy
+from analytics.taxonomy import load_taxonomy_entries, map_text_to_taxonomy, match_taxonomy
 
 st.markdown("<style>" + pathlib.Path("assets/theme.css").read_text() + "</style>", unsafe_allow_html=True)
 st.title("📊 Drivers & Visualization")
@@ -69,8 +69,6 @@ with st.expander("Map to DWPNxt Taxonomy & Reconcile", expanded=True):
         # merged
         refined["final_driver"] = refined.apply(lambda r: r["taxonomy_match"] if (pd.notna(r["taxonomy_match"]) and r["taxonomy_score"]>=2) else r["driver"], axis=1)
     # --- Taxonomy conflict fix & fill 'Other' ---
-    from analytics.taxonomy import load_taxonomy_entries, match_taxonomy
-    entries = load_taxonomy_entries()
     tx = refined["text"].astype(str).apply(lambda t: match_taxonomy(t, entries))
     refined["taxonomy_match"] = tx.apply(lambda r: r[0])
     refined["taxonomy_score"] = tx.apply(lambda r: r[1])


### PR DESCRIPTION
## Summary
- Import taxonomy matching helper at top of drivers visualization page
- Load taxonomy entries once per session and reuse for conflict resolution

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68acf59d6cd48331864da0b48a6f891e