### PR TITLE
Cache rules YAML parsing

### DIFF
--- a/analytics/tcd.py
+++ b/analytics/tcd.py
@@ -1,5 +1,7 @@
 import re, pandas as pd, yaml
+from functools import lru_cache
 
+@lru_cache(maxsize=1)
 def load_rules(path="analytics/rules.yaml"):
     with open(path, "r") as f:
         return yaml.safe_load(f)["rules"]


### PR DESCRIPTION
## Summary
- cache analytics rules YAML parsing via functools.lru_cache in `load_rules`

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68acf5ab9f388331b3700e441057e52e