### PR TITLE
Vectorized driver derivation with cached regex rules

### DIFF
--- a/analytics/tcd.py
+++ b/analytics/tcd.py
@@ -3,8 +3,16 @@ from functools import lru_cache
 
 @lru_cache(maxsize=1)
 def load_rules(path="analytics/rules.yaml"):
+    """Load rule definitions and compile regex patterns with caching."""
     with open(path, "r") as f:
-        return yaml.safe_load(f)["rules"]
+        rules = yaml.safe_load(f)["rules"]
+
+    compiled = []
+    for rule in rules:
+        words = [re.escape(w) for w in rule["keywords"]]
+        pattern = re.compile(r"\b(?:" + "|".join(words) + r")\b", flags=re.IGNORECASE)
+        compiled.append({"name": rule["name"], "regex": pattern})
+    return compiled
 
 def normalize_text(s):
     s = "" if s is None else str(s)
@@ -19,6 +27,7 @@ def _safe_text_series(df: pd.DataFrame, col_name: str) -> pd.Series:
     return pd.Series([""] * len(df), index=df.index, dtype="string")
 
 def derive_drivers(df, rules):
+    """Derive ticket drivers by applying cached regex patterns."""
     df = df.copy()
     cols = {c.lower().strip(): c for c in df.columns}
     sd_col = cols.get("short_description") or cols.get("short description") or "short_description"
@@ -26,15 +35,19 @@ def derive_drivers(df, rules):
     sd = _safe_text_series(df, sd_col)
     desc = _safe_text_series(df, d_col)
     text_joined = (sd + " " + desc).map(normalize_text)
-    buckets = []
-    for t in text_joined:
-        hit = None
-        for rule in rules:
-            if any(k in t for k in rule["keywords"]):
-                hit = rule["name"]; break
-        buckets.append(hit or "Other")
-    df["driver"] = buckets
-    return df, df.groupby("driver").size().reset_index(name="tickets").sort_values("tickets", ascending=False)
+
+    df["driver"] = "Other"
+    for rule in rules:
+        mask = text_joined.str.contains(rule["regex"], na=False)
+        df.loc[mask & (df["driver"] == "Other"), "driver"] = rule["name"]
+
+    summary = (
+        df.groupby("driver")
+        .size()
+        .reset_index(name="tickets")
+        .sort_values("tickets", ascending=False)
+    )
+    return df, summary
 
 def estimate_aht_minutes(df, default=8.0):
     for candidate in ["u_aht_minutes","AHT","avg_handle_time"]:


### PR DESCRIPTION
## Summary
- Cache compiled regex patterns for top call driver rules with word boundaries and case-insensitive flags
- Use vectorized `str.contains` matches to assign drivers, avoiding per-row loops

## Testing
- `pytest -q`
- `python -m py_compile analytics/tcd.py`


------
https://chatgpt.com/codex/tasks/task_e_68af5dd919fc83318a7daaa9496e86b4