### PR TITLE
Precompile taxonomy regex patterns for faster matching

### DIFF
--- a/pages/2_📊_Drivers_&_Visualization.py
+++ b/pages/2_📊_Drivers_&_Visualization.py
@@ -2,7 +2,12 @@ import streamlit as st, pandas as pd, plotly.express as px, pathlib
 from analytics.tcd import load_rules, derive_drivers
 from analytics.cluster import iterative_other_reduction
 from analytics.llm_bridge import best_label_for_cluster
-from analytics.taxonomy import load_taxonomy_entries, map_text_to_taxonomy, match_taxonomy
+from analytics.taxonomy import (
+    load_taxonomy_entries,
+    compile_taxonomy_entries,
+    map_text_to_taxonomy,
+    match_taxonomy,
+)
 
 st.markdown("<style>" + pathlib.Path("assets/theme.css").read_text() + "</style>", unsafe_allow_html=True)
 st.title("📊 Drivers & Visualization")
@@ -55,7 +60,7 @@ if refined is None or freq_all is None or fig_top is None or dirty:
 
     # 3) Taxonomy mapping + reconciliation
     with st.expander("Map to DWPNxt Taxonomy & Reconcile", expanded=True):
-        entries = load_taxonomy_entries()
+        entries = compile_taxonomy_entries(load_taxonomy_entries())
         # taxonomy score per row
         titles, scores = [], []
         for txt in refined["text"].astype(str).tolist():


### PR DESCRIPTION
## Summary
- add CompiledTaxEntry and compile_taxonomy_entries to precompile taxonomy regex patterns
- update match_taxonomy to consume compiled patterns and avoid repeated compilation
- adjust Drivers & Visualization page to compile taxonomy entries before matching

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68af5ddae09c83319495de8b268e357f