### PR TITLE
Add call-driver keywords and rules validator

### DIFF
--- a/analytics/rules.yaml
+++ b/analytics/rules.yaml
@@ -5,3 +5,9 @@ rules:
     keywords: ["status", "check status", "where is", "eta", "update", "progress"]
   - name: Access Provisioning (Standard)
     keywords: ["access", "add to group", "license", "entitle", "provision"]
+  - name: VPN Issues
+    keywords: ["vpn", "virtual private network", "remote access", "globalprotect", "anyconnect", "netextender"]
+  - name: Email Issues
+    keywords: ["email", "outlook", "mailbox", "inbox", "exchange", "o365", "office 365", "gmail"]
+  - name: Hardware Issues
+    keywords: ["laptop", "desktop", "computer", "hardware", "device", "monitor", "keyboard", "mouse", "printer"]

--- a/analytics/rules_validator.py
+++ b/analytics/rules_validator.py
@@ -1,0 +1,52 @@
+import collections
+import yaml
+
+
+def validate_rules(path: str = "analytics/rules.yaml"):
+    """Validate keyword rules for empties and duplicates.
+
+    Returns a list of warning strings.
+    """
+    with open(path, "r") as f:
+        data = yaml.safe_load(f) or {}
+    rules = data.get("rules", [])
+    warnings = []
+
+    seen_keywords = set()
+    for rule in rules:
+        name = rule.get("name", "<unnamed>")
+        keywords = rule.get("keywords") or []
+        if not keywords:
+            warnings.append(f"Rule '{name}' has no keywords")
+            continue
+        # check duplicates within a rule
+        counts = collections.Counter(k.lower() for k in keywords)
+        dups = [k for k, c in counts.items() if c > 1]
+        if dups:
+            warnings.append(
+                f"Rule '{name}' has duplicate keywords: {', '.join(sorted(dups))}"
+            )
+        # check duplicates across rules
+        overlap = [k for k in (k.lower() for k in keywords) if k in seen_keywords]
+        if overlap:
+            warnings.append(
+                f"Rule '{name}' shares keywords with other rules: {', '.join(sorted(set(overlap)))}"
+            )
+        seen_keywords.update(k.lower() for k in keywords)
+    # check for identical keyword sets
+    sets = {}
+    for rule in rules:
+        name = rule.get("name", "<unnamed>")
+        key = tuple(sorted(k.lower() for k in (rule.get("keywords") or [])))
+        if key in sets:
+            warnings.append(
+                f"Rule '{name}' has the same keywords as rule '{sets[key]}'"
+            )
+        else:
+            sets[key] = name
+    return warnings
+
+
+if __name__ == "__main__":
+    for w in validate_rules():
+        print("WARNING:", w)


### PR DESCRIPTION
## Summary
- extend analytics rules with VPN, email and hardware keywords
- add a validator to flag empty or duplicated rule keywords

## Testing
- `python analytics/rules_validator.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68af5dddadb483318a8738d5f6518a2c