### PR TITLE
feat: add scalable vectorization options

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,3 +17,10 @@ pip install --force-reinstall --no-build-isolation pandas==2.2.2
 If the app runs behind a reverse proxy (e.g., Nginx), ensure the proxy's
 `client_max_body_size` matches the `maxUploadSize` in `.streamlit/config.toml`
 so large workbook uploads aren't rejected.
+
+## Large dataset tuning
+The **Upload & Settings** page exposes advanced text-processing options:
+- switch between TF‑IDF and Hashing vectorizers
+- limit feature count
+- enable incremental SVD via batch size
+These settings help scale analyses to ~100K records.

--- a/analytics/cluster.py
+++ b/analytics/cluster.py
@@ -1,8 +1,8 @@
 import numpy as np, pandas as pd, re
 from typing import Tuple, Dict
-from sklearn.feature_extraction.text import TfidfVectorizer
+from sklearn.feature_extraction.text import TfidfVectorizer, HashingVectorizer, TfidfTransformer
 from sklearn.cluster import KMeans
-from sklearn.decomposition import TruncatedSVD
+from sklearn.decomposition import TruncatedSVD, IncrementalPCA
 from collections import Counter
 from sklearn.feature_extraction import text
 
@@ -20,24 +20,52 @@ def _clean_text(s):
     s = re.sub(r"\s+", " ", s).strip()
     return s
 
-def _build_vectorizer():
-    return TfidfVectorizer(
-        lowercase=True,
-        strip_accents="unicode",
-        ngram_range=(1,2),
-        analyzer="word",
-        stop_words=list(CUSTOM_STOPWORDS),
-        min_df=2,
-        max_df=0.85,
-        max_features=30000
-    )
+def _build_vectorizer(use_hashing=False, max_features=30000):
+    if use_hashing:
+        vec = HashingVectorizer(
+            lowercase=True,
+            strip_accents="unicode",
+            ngram_range=(1,2),
+            analyzer="word",
+            stop_words=list(CUSTOM_STOPWORDS),
+            n_features=max_features,
+            alternate_sign=False
+        )
+        tfidf = TfidfTransformer()
+        return vec, tfidf
+    else:
+        vec = TfidfVectorizer(
+            lowercase=True,
+            strip_accents="unicode",
+            ngram_range=(1,2),
+            analyzer="word",
+            stop_words=list(CUSTOM_STOPWORDS),
+            min_df=2,
+            max_df=0.85,
+            max_features=max_features
+        )
+        return vec, None
 
-def featurize(texts: pd.Series):
+def featurize(texts: pd.Series,
+              use_hashing: bool = False,
+              max_features: int = 30000,
+              svd_batch_size: int | None = None):
     texts = texts.map(_clean_text)
-    vec = _build_vectorizer()
-    X = vec.fit_transform(texts.tolist())
-    svd = TruncatedSVD(n_components=min(100, max(2, int(X.shape[1]*0.2))), random_state=42)
-    Xs = svd.fit_transform(X)
+    vec, tfidf = _build_vectorizer(use_hashing=use_hashing, max_features=max_features)
+    if use_hashing:
+        X = vec.transform(texts.tolist())
+        X = tfidf.fit_transform(X)
+    else:
+        X = vec.fit_transform(texts.tolist())
+    n_comp = min(100, max(2, int(X.shape[1]*0.2)))
+    if svd_batch_size:
+        svd = IncrementalPCA(n_components=n_comp, batch_size=svd_batch_size)
+        for start in range(0, X.shape[0], svd_batch_size):
+            svd.partial_fit(X[start:start+svd_batch_size].toarray())
+        Xs = svd.transform(X.toarray())
+    else:
+        svd = TruncatedSVD(n_components=n_comp, random_state=42)
+        Xs = svd.fit_transform(X)
     return X, Xs, vec, svd
 
 def try_hdbscan(Xs, min_cluster_size=25, min_samples=None):
@@ -56,11 +84,17 @@ def run_clustering(texts: pd.Series | None = None,
                    X=None,
                    Xs=None,
                    vec=None,
-                   svd=None) -> Tuple[np.ndarray,str,Dict]:
+                   svd=None,
+                   use_hashing: bool = False,
+                   max_features: int = 30000,
+                   svd_batch_size: int | None = None) -> Tuple[np.ndarray,str,Dict]:
     if X is None or Xs is None or vec is None or svd is None:
         if texts is None:
             raise ValueError("Either texts or precomputed features must be provided")
-        X, Xs, vec, svd = featurize(texts)
+        X, Xs, vec, svd = featurize(texts,
+                                    use_hashing=use_hashing,
+                                    max_features=max_features,
+                                    svd_batch_size=svd_batch_size)
     labels, algo, model = try_hdbscan(Xs, min_cluster_size=min_cluster_size)
     if labels is None or (labels.astype(int) < 0).all():
         km = KMeans(n_clusters=min(kmeans_k, max(2, int(Xs.shape[0]/min_cluster_size))), random_state=42, n_init="auto")
@@ -71,9 +105,15 @@ def run_clustering(texts: pd.Series | None = None,
 def iterative_other_reduction(df: pd.DataFrame,
                               target_other_pct=0.12,
                               max_rounds=3,
-                              min_cluster_size=25) -> pd.DataFrame:
+                              min_cluster_size=25,
+                              use_hashing: bool = False,
+                              max_features: int = 30000,
+                              svd_batch_size: int | None = None) -> pd.DataFrame:
     df = df.copy()
-    X, Xs, vec, svd = featurize(df["text"])
+    X, Xs, vec, svd = featurize(df["text"],
+                                use_hashing=use_hashing,
+                                max_features=max_features,
+                                svd_batch_size=svd_batch_size)
     for _ in range(max_rounds):
         mask = df["driver"]=="Other"
         if not mask.any(): break

--- a/analytics/prefs.py
+++ b/analytics/prefs.py
@@ -4,6 +4,9 @@ DEFAULT_PREFS = {
   "min_cluster_size": 25,
   "target_other_pct": 12,
   "include_other": False,
+  "vectorizer": "tfidf",      # tfidf or hashing
+  "max_features": 30000,       # features for Tfidf/Hashing vectorizers
+  "svd_batch_size": 0,         # 0 = fit all at once
   "cost_per_min": 1.20,
   "deflection_pct": 35,
 }

--- a/pages/1_📥_Upload_&_Settings.py
+++ b/pages/1_📥_Upload_&_Settings.py
@@ -77,6 +77,12 @@ with st.expander("Clustering & Coverage", expanded=True):
     prefs["target_other_pct"] = c2.slider("Target 'Other' max %", 0, 50, int(prefs.get("target_other_pct",12)), 1)
     prefs["include_other"] = c3.checkbox("Include 'Other' in outputs", value=bool(prefs.get("include_other",False)))
 
+with st.expander("Vectorization", expanded=False):
+    c1,c2,c3 = st.columns(3)
+    prefs["vectorizer"] = c1.selectbox("Vectorizer", ["tfidf","hashing"], index=["tfidf","hashing"].index(prefs.get("vectorizer","tfidf")))
+    prefs["max_features"] = c2.number_input("Max features", 1000, 200000, int(prefs.get("max_features",30000)), 1000)
+    prefs["svd_batch_size"] = c3.number_input("SVD batch size (0=all)", 0, 10000, int(prefs.get("svd_batch_size",0)), 100)
+
 with st.expander("Save / Load Settings", expanded=False):
     c1,c2 = st.columns(2)
     with c1:
@@ -89,5 +95,8 @@ with st.expander("Save / Load Settings", expanded=False):
             prefs["OPENAI_API_KEY"] = os.environ.get("OPENAI_API_KEY","")
             path = save_prefs(prefs=prefs, include_keys=True)
             st.warning(f"Saved with keys to {path} (be cautious with git).")
+
+for k in ["llm_provider","min_cluster_size","target_other_pct","include_other","vectorizer","max_features","svd_batch_size"]:
+    st.session_state[k] = prefs.get(k)
 
 st.info("Next → open **📊 Drivers & Visualization**")

--- a/pages/2_📊_Drivers_&_Visualization.py
+++ b/pages/2_📊_Drivers_&_Visualization.py
@@ -16,6 +16,10 @@ include_other = bool(st.session_state.get("include_other", False))
 min_cluster_size = int(st.session_state.get("min_cluster_size", 25))
 target_other = float(st.session_state.get("target_other_pct", 12))/100.0
 provider = st.session_state.get("llm_provider","auto")
+vec_choice = st.session_state.get("vectorizer", "tfidf")
+max_features = int(st.session_state.get("max_features", 30000))
+svd_batch_size = int(st.session_state.get("svd_batch_size", 0))
+use_hashing = vec_choice == "hashing"
 dirty = st.session_state.get("dirty", False)
 refined = st.session_state.get("refined")
 freq_all = st.session_state.get("freq_all")
@@ -34,7 +38,15 @@ if refined is None or freq_all is None or fig_top is None or dirty:
 
     # 2) Clustering + iterative reduction + Python/LLM rename (cluster names)
     with st.expander("Clustering on 'Other' + Intelligent Labeling (Python-first, LLM optional)", expanded=True):
-        refined = iterative_other_reduction(tcd_df, target_other_pct=target_other, max_rounds=3, min_cluster_size=min_cluster_size)
+        refined = iterative_other_reduction(
+            tcd_df,
+            target_other_pct=target_other,
+            max_rounds=3,
+            min_cluster_size=min_cluster_size,
+            use_hashing=use_hashing,
+            max_features=max_features,
+            svd_batch_size=(svd_batch_size or None)
+        )
 
         # Rename all discovered cluster_* or "Other" buckets via bridge (Python → LLM when keys present)
         renamed = {}


### PR DESCRIPTION
## Summary
- allow choosing between TF-IDF and HashingVectorizer with feature limits
- add incremental SVD option via batch sizing
- expose new vectorization controls in settings for large datasets

## Testing
- `python -m py_compile analytics/prefs.py analytics/cluster.py 'pages/1_📥_Upload_&_Settings.py' 'pages/2_📊_Drivers_&_Visualization.py'`


------
https://chatgpt.com/codex/tasks/task_e_68af5dde77c08331992387d432fad53e