### PR TITLE
Fix taxonomy matching to use compiled patterns

### DIFF
--- a/analytics/taxonomy.py
+++ b/analytics/taxonomy.py
@@ -11,9 +11,9 @@ class TaxEntry:
 
 @dataclass
 class CompiledTaxEntry:
-    """Taxonomy entry with precompiled regex patterns."""
+    """Taxonomy entry with precompiled regex patterns and weights."""
     name: str
-    phrase_patterns: List[Pattern]
+    phrase_patterns: List[Tuple[Pattern, float]]
     token_patterns: List[Tuple[Pattern, float]]
 
 def save_taxonomy(data: Dict[str, Any], path: str = "config/taxonomy.yaml") -> None:
@@ -72,17 +72,21 @@ def compile_taxonomy_entries(entries: List[TaxEntry]) -> List[CompiledTaxEntry]:
     """Precompile regex patterns for each taxonomy entry."""
     compiled: List[CompiledTaxEntry] = []
     for e in entries:
-        phrase_pats: List[Pattern] = []
+        phrase_pats: List[Tuple[Pattern, float]] = []
         token_pats: List[Tuple[Pattern, float]] = []
-        for syn in e.synonyms:
+        for syn, wt in e.synonyms.items():
             if " " in syn:
-                phrase_pats.append(re.compile(re.escape(syn)))
+                phrase_pats.append((re.compile(re.escape(syn)), wt))
             else:
-                weight = 1.0 if syn not in GENERIC_WEAK else 0.25
-                token_pats.append((re.compile(r"\b" + re.escape(syn) + r"\b"), weight))
-        compiled.append(CompiledTaxEntry(name=e.name,
-                                        phrase_patterns=phrase_pats,
-                                        token_patterns=token_pats))
+                base = 0.25 if syn in GENERIC_WEAK else 1.0
+                token_pats.append((re.compile(r"\b" + re.escape(syn) + r"\b"), wt * base))
+        compiled.append(
+            CompiledTaxEntry(
+                name=e.name,
+                phrase_patterns=phrase_pats,
+                token_patterns=token_pats,
+            )
+        )
     return compiled
 
 # Strong phrase patterns to resolve conflicts
@@ -113,17 +117,15 @@ GENERIC_WEAK = {"access"}  # downweight generic token
 def match_taxonomy(text: str, entries: List[CompiledTaxEntry]) -> Tuple[str, float]:
     t = (text or "").lower()
 
-    phrase_hits = {e.name:0.0 for e in entries}
-    token_hits  = {e.name:0.0 for e in entries}
+    phrase_hits = {e.name: 0.0 for e in entries}
+    token_hits = {e.name: 0.0 for e in entries}
     for e in entries:
-        for syn, wt in e.synonyms.items():
-            if " " in syn:
-                if syn in t:
-                    phrase_hits[e.name] += 3 * wt
-            else:
-                if re.search(r"\b"+re.escape(syn)+r"\b", t):
-                    token_hits[e.name] += 1 * wt
-
+        for pat, wt in e.phrase_patterns:
+            if pat.search(t):
+                phrase_hits[e.name] += 3 * wt
+        for pat, wt in e.token_patterns:
+            if pat.search(t):
+                token_hits[e.name] += 1 * wt
 
     network_ap_hit = any(p.search(t) for p in NETWORK_AP_REGEXES)
     access_prov_hit = any(p.search(t) for p in ACCESS_PROV_REGEXES)


### PR DESCRIPTION
## Summary
- include weights alongside compiled regex patterns for taxonomy entries
- match taxonomy text using precompiled phrase and token patterns

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b0428e67dc8331a57777122aa09ec2