### PR TITLE
Use non-capturing group for access point regex

### DIFF
--- a/pages/2_📊_Drivers_&_Visualization.py
+++ b/pages/2_📊_Drivers_&_Visualization.py
@@ -96,7 +96,7 @@ if refined is None or freq_all is None or fig_top is None or dirty:
         refined["taxonomy_score"] = tx.apply(lambda r: r[1])
 
         # Force “access point”-style incidents to Network Hardware / Interface
-        mask_ap = refined["text"].str.contains(r"\b(access point|wlc|wireless controller|wlan|ssid|thin ap|gigabitethernet)\b", case=False, na=False)
+        mask_ap = refined["text"].str.contains(r"\b(?:access point|wlc|wireless controller|wlan|ssid|thin ap|gigabitethernet)\b", case=False, na=False)
         refined.loc[mask_ap, "final_driver"] = "Network Hardware / Interface"
 
         # If driver is Other but taxonomy is confident, adopt taxonomy name


### PR DESCRIPTION
## Summary
- use non-capturing group in access point regex for `mask_ap`

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b05cc7f9008331ae7e1eec48b23614